### PR TITLE
Rahman/Openstack - Adding new configuration to cinder and nova Kolla deployment templates

### DIFF
--- a/ansible/roles/cinder/templates/cinder.conf.j2
+++ b/ansible/roles/cinder/templates/cinder.conf.j2
@@ -103,6 +103,8 @@ max_pool_size = {{ database_max_pool_size }}
 max_retries = -1
 
 [keystone_authtoken]
+service_token_roles = service
+service_token_roles_required = true
 service_type = volume
 www_authenticate_uri = {{ keystone_internal_url }}
 auth_url = {{ keystone_internal_url }}

--- a/ansible/roles/nova-cell/templates/nova.conf.j2
+++ b/ansible/roles/nova-cell/templates/nova.conf.j2
@@ -253,3 +253,21 @@ track_instance_changes = false
 [pci]
 passthrough_whitelist = {{ nova_pci_passthrough_whitelist | to_json }}
 {% endif %}
+
+[service_user]
+send_service_user_token = True
+service_type = compute
+www_authenticate_uri = {{ keystone_internal_url }}
+auth_url = {{ keystone_internal_url }}
+auth_type = password
+project_domain_id = {{ default_project_domain_id }}
+user_domain_id = {{ default_user_domain_id }}
+project_name = service
+username = {{ nova_keystone_user }}
+password = {{ nova_keystone_password }}
+cafile = {{ openstack_cacert }}
+region_name = {{ openstack_region_name }}
+
+memcache_security_strategy = ENCRYPT
+memcache_secret_key = {{ memcache_secret_key }}
+memcached_servers = {% for host in groups['memcached'] %}{{ 'api' | kolla_address(host) | put_address_in_context('memcache') }}:{{ memcached_port }}{% if not loop.last %},{% endif %}{% endfor %}

--- a/ansible/roles/nova/templates/nova.conf.j2
+++ b/ansible/roles/nova/templates/nova.conf.j2
@@ -207,3 +207,21 @@ auth_endpoint = {{ keystone_internal_url }}
 barbican_endpoint_type = internal
 verify_ssl_path = {{ openstack_cacert }}
 {% endif %}
+
+[service_user]
+send_service_user_token = True
+service_type = compute
+www_authenticate_uri = {{ keystone_internal_url }}
+auth_url = {{ keystone_internal_url }}
+auth_type = password
+project_domain_id = {{ default_project_domain_id }}
+user_domain_id = {{ default_user_domain_id }}
+project_name = service
+username = {{ nova_keystone_user }}
+password = {{ nova_keystone_password }}
+cafile = {{ openstack_cacert }}
+region_name = {{ openstack_region_name }}
+
+memcache_security_strategy = ENCRYPT
+memcache_secret_key = {{ memcache_secret_key }}
+memcached_servers = {% for host in groups['memcached'] %}{{ 'api' | kolla_address(host) | put_address_in_context('memcache') }}:{{ memcached_port }}{% if not loop.last %},{% endif %}{% endfor %}


### PR DESCRIPTION
Openstack community fixed a security vulnerability by mandating to use service-token along with user-token when a request is made from one service to another service. This change broke the current CI and when a volume is detach from an instance. 
This change will enable NOVA to send a service-token and CINDER to validate that token before a volume is detach. 

Issue: LBM1-27398