### PR TITLE
add env variable to all dockers

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -154,6 +154,7 @@ docker_common_options:
   auth_username: "{{ docker_registry_username }}"
   environment:
     KOLLA_CONFIG_STRATEGY: "{{ config_strategy }}"
+    VIRTUAL_ENV: true
   restart_policy: "{{ docker_restart_policy }}"
   restart_retries: "{{ docker_restart_policy_retry }}"
   graceful_timeout: "{{ docker_graceful_timeout }}"

--- a/ansible/roles/cinder/templates/cinder.conf.j2
+++ b/ansible/roles/cinder/templates/cinder.conf.j2
@@ -1,6 +1,5 @@
 [DEFAULT]
 debug = {{ cinder_logging_debug }}
-
 log_dir = /var/log/kolla/cinder
 {% if service_name == "cinder-api" %}
 log_file = cinder-api.log
@@ -13,7 +12,9 @@ use_stderr = False
 
 my_ip = {{ api_interface_address }}
 
-volume_name_template = volume-%s
+
+osapi_volume_workers = {{ openstack_service_workers }}
+volume_name_template = vol_%s
 
 glance_api_servers = {{ glance_internal_endpoint }}
 
@@ -112,6 +113,8 @@ max_pool_size = {{ database_max_pool_size }}
 max_retries = -1
 
 [keystone_authtoken]
+service_token_roles = service
+service_token_roles_required = true
 service_type = volume
 # security fix, always validate service tokens
 # see: https://security.openstack.org/ossa/OSSA-2023-003.html
@@ -237,8 +240,8 @@ san_ip = {{ pure_san_ip }}
 pure_api_token = {{ pure_api_token }}
 {% endif %}
 
-[privsep_entrypoint]
-helper_command=sudo cinder-rootwrap /etc/cinder/rootwrap.conf privsep-helper --config-file /etc/cinder/cinder.conf
+[privsep_osbrick]
+helper_command = sudo -E cinder-rootwrap /etc/cinder/rootwrap.conf privsep-helper --config-file /etc/cinder/cinder.conf
 
 {% if enable_osprofiler | bool %}
 [profiler]

--- a/ansible/roles/nova-cell/templates/nova.conf.j2
+++ b/ansible/roles/nova-cell/templates/nova.conf.j2
@@ -207,8 +207,8 @@ rabbit_quorum_queue = true
 policy_file = {{ nova_policy_file }}
 {% endif %}
 
-[privsep_entrypoint]
-helper_command=sudo nova-rootwrap /etc/nova/rootwrap.conf privsep-helper --config-file /etc/nova/nova.conf
+[privsep_osbrick]
+helper_command = sudo -E nova-rootwrap /etc/nova/rootwrap.conf privsep-helper --config-file /etc/nova/nova.conf
 
 [guestfs]
 debug = {{ nova_logging_debug }}
@@ -268,7 +268,9 @@ passthrough_whitelist = {{ nova_pci_passthrough_whitelist | to_json }}
 {% endif %}
 
 [service_user]
-send_service_user_token = true
+send_service_user_token = True
+service_type = compute
+www_authenticate_uri = {{ keystone_internal_url }}
 auth_url = {{ keystone_internal_url }}
 auth_type = password
 project_domain_id = {{ default_project_domain_id }}
@@ -279,3 +281,6 @@ password = {{ nova_keystone_password }}
 cafile = {{ openstack_cacert }}
 region_name = {{ openstack_region_name }}
 valid_interfaces = internal
+memcache_security_strategy = ENCRYPT
+memcache_secret_key = {{ memcache_secret_key }}
+memcached_servers = {% for host in groups['memcached'] %}{{ 'api' | kolla_address(host) | put_address_in_context('memcache') }}:{{ memcached_port }}{% if not loop.last %},{% endif %}{% endfor %}

--- a/ansible/roles/nova/templates/nova.conf.j2
+++ b/ansible/roles/nova/templates/nova.conf.j2
@@ -156,8 +156,8 @@ rabbit_quorum_queue = true
 policy_file = {{ nova_policy_file }}
 {% endif %}
 
-[privsep_entrypoint]
-helper_command=sudo nova-rootwrap /etc/nova/rootwrap.conf privsep-helper --config-file /etc/nova/nova.conf
+[privsep_osbrick]
+helper_command = sudo -E nova-rootwrap /etc/nova/rootwrap.conf privsep-helper --config-file /etc/nova/nova.conf
 
 [guestfs]
 debug = {{ nova_logging_debug }}
@@ -209,7 +209,9 @@ verify_ssl_path = {{ openstack_cacert }}
 {% endif %}
 
 [service_user]
-send_service_user_token = true
+send_service_user_token = True
+service_type = compute
+www_authenticate_uri = {{ keystone_internal_url }}
 auth_url = {{ keystone_internal_url }}
 auth_type = password
 project_domain_id = {{ default_project_domain_id }}
@@ -220,3 +222,6 @@ password = {{ nova_keystone_password }}
 cafile = {{ openstack_cacert }}
 region_name = {{ openstack_region_name }}
 valid_interfaces = internal
+memcache_security_strategy = ENCRYPT
+memcache_secret_key = {{ memcache_secret_key }}
+memcached_servers = {% for host in groups['memcached'] %}{{ 'api' | kolla_address(host) | put_address_in_context('memcache') }}:{{ memcached_port }}{% if not loop.last %},{% endif %}{% endfor %}


### PR DESCRIPTION
VIRUTAL_ENV:true used in our connector

update privsep section

we need the privsep section to keep the env variable while using os-brick to have the "VIRTUAL_ENV" variable. this gives more capabilities to the process

update privsep section in nova.conf

update privsep section for nova - keeping the env variable.

fix copy-paste typo - cinder->nova in nova.conf

update volume_name_template to fit out tests framework

remove duplicate volume_name_template

update nova-cell roles to use os_brick priv

adding service token usage to nova.conf and cinder.conf configuration file

updating the nova cell template for nova.conf file