### PR TITLE
Pin openstack.kolla collection to stable/2025.1

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -2,4 +2,4 @@
 collections:
   - name: https://opendev.org/openstack/ansible-collection-kolla
     type: git
-    version: master
+    version: stable/2025.1


### PR DESCRIPTION
## Summary
- Pin `openstack.kolla` ansible collection from `master` to `stable/2025.1`
- Using `master` caused kolla-ansible deploy failures when upstream introduced breaking changes (e.g. `No module named 'requests'` in the `Get Docker system info` task)
- Verified `stable/2025.1` works with `bootstrap-servers`

## Test plan
- [x] Run `kolla-ansible bootstrap-servers` on rack04-server66 — passed on all nodes

🤖 Generated with [Claude Code](https://claude.com/claude-code)